### PR TITLE
pytest-cov バッジの追加、PR, issueのテンプレート作成

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/refactoring_report.md
+++ b/.github/ISSUE_TEMPLATE/refactoring_report.md
@@ -1,0 +1,20 @@
+---
+name: Refactoring report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe where is need to be refactored**
+A clear and concise description of where is need to be improved.
+
+**Expected codes**
+please write clearly what is expected to be changed.
+
+**Screenshots**
+If applicable, add screenshots to help explain your issue.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Description
+
+Belongs to: # (reference the issue ID or Notion URL here)
+
+## Overview of Changes
+
+<!-- Provide a bulleted list of changes here -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Refactor (non-breaking change that only restructures code)
+- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
+
+## Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have checked my code and corrected any misspellings
+
+## For Reviewers
+
+for more information, see [the style guide]()
+
+レビュアーが参照した方が良いと思われるリンクや、参考資料を記載

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,3 +25,15 @@ jobs:
         with:
             pytest-coverage-path: pytest-coverage.txt
             junitxml-path: ./pytest.xml
+
+      - name: Create Coverage Badge
+        uses: schneegans/dynamic-badges-action@v1.3.0
+        with:
+            auth: ${{ secrets.BADGE_GIST }}
+            gistID: 9c19de175b7ce5bcfd2eb2ed26a60d40
+
+            filename: pytest-coverage-comment.json
+            label: Coverage
+            message: ${{ steps.coverageComment.outputs.coverage }}
+            color: ${{ steps.coverageComment.outputs.color }}
+            namedLogo: python

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,5 +1,7 @@
 name: Pytest
 on: push
+permissions: write-all
+
 jobs:
   pytest:
     runs-on: ubuntu-latest
@@ -15,4 +17,11 @@ jobs:
           pip install -r requirements.txt
       - name: Run pytest
         run: |
-          pytest
+          pytest --cov --junitxml=pytest.xml --cov-report=term-missing:skip-covered | tee pytest-coverage.txt
+
+      - name: Create Coverage Comment
+        id: coverageComment
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+            pytest-coverage-path: pytest-coverage.txt
+            junitxml-path: ./pytest.xml

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # address-complete-divide
 ![pytest](https://github.com/haruboring/address-complete-divide/actions/workflows/pytest.yml/badge.svg)
 ![flake8 & black](https://github.com/haruboring/address-complete-divide/actions/workflows/linter.yml/badge.svg)
-
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/haruboring/9c19de175b7ce5bcfd2eb2ed26a60d40/raw/pytest-coverage-comment.json)](https://github.com/haruboring/address-complete-divide-api/actions/workflows/pytest.yml)
 
 ## About
 

--- a/pytest.xml
+++ b/pytest.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite name="pytest" errors="0" failures="0" skipped="0" tests="1" time="0.038" timestamp="2023-05-16T03:56:58.820384" hostname="harub.local"><testcase classname="tests.test_temp.TestTemp" name="test_temp" time="0.001" /></testsuite></testsuites>


### PR DESCRIPTION
具体的には以下の変更を行った

- covバッジの追加（参考記事 : [Github Actions+Gistでカバレッジ可視化～無課金プライベートリポジトリでもカバレッジバッジが欲しい～](https://zenn.dev/u_not/articles/a27fb7264b3ea7)）
- PR, issue時のテンプレートの追加